### PR TITLE
Observable value upon access

### DIFF
--- a/nasim/envs/state.py
+++ b/nasim/envs/state.py
@@ -169,18 +169,10 @@ class State:
             obs_kwargs["services"] = True
             obs_kwargs["os"] = True
             obs_kwargs["access"] = True
-            # if action.access == AccessLevel.ROOT:
-            if action_result.value > 0:
-                # Means exploit gained ROOT access for first time
-                # So observe value
-                obs_kwargs["value"] = True
+            obs_kwargs["value"] = True
         elif action.is_privilege_escalation():
             obs_kwargs["compromised"] = True
             obs_kwargs["access"] = True
-            if action_result.value > 0:
-                # Means exploit gained ROOT access for first time
-                # So observe value
-                obs_kwargs["value"] = True
         elif action.is_service_scan():
             obs_kwargs["services"] = True
         elif action.is_os_scan():


### PR DESCRIPTION
With a randomly generated goal in partial-observable scenario, there is no way to know which of the hosts is valuable. The value is observed only when a root access is gained on the sensitive hosts, which usually also terminates the episode. Hence the agent can only randomly try different hosts. 

In reality, usually the pentester knows that there could be some sensitive data on a host immediately when gaining even a user-level access (however, the data may be inaccessible until it gains root). 

So I propose a change to disclose the node's value upon gaining any access. It is more realistic, and the agent can learn a more interesting policy - instead of random sampling, it can learn to prioritize gaining root only on sensitive nodes.