### PR TITLE
Fixed typo and corrections to array dimensions

### DIFF
--- a/nasim/envs/action.py
+++ b/nasim/envs/action.py
@@ -729,16 +729,16 @@ class ParameterisedActionSpace(spaces.MultiDiscrete):
        -1 since we don't include the internet subnet
 
     2. Host = [0, max subnets size-1]
-    3. OS = [0, #OS+1]
+    3. OS = [0, #OS]
 
        Where 0=None.
 
-    4. Service = [0, #services]
-    5. Process = [0, #processes+1]
+    4. Service = [0, #services - 1]
+    5. Process = [0, #processes]
 
        Where 0=None.
 
-    Note that OS, Service and Process are only importand for exploits and
+    Note that OS, Service and Process are only important for exploits and
     privilege escalation actions.
 
     ...


### PR DESCRIPTION
Fixed typo. Moreover, some array dimensions were not correct: the number of OS and Processes doesn't need to be "+1", even if the 0 position of the array belongs to "None". Moreover, the number of the dimension of the services array should be "#services - 1".