### PR TITLE
fix: include agent/policies pt files in package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     extras_require=extras,
     python_requires='>=3.8',
     package_data={
-        'nasim': ['scenarios/benchmark/*.yaml']
+        'nasim': ['scenarios/benchmark/*.yaml', 'agents/policies/*.pt']
     },
     project_urls={
         'Documentation': "https://networkattacksimulator.readthedocs.io",


### PR DESCRIPTION
This PR includes `agent/policies/*.pt` files in the package_data so that this directory is accessible after pip install of nasim.

closes #40 