### PR TITLE
env.get_action_mask function accesses wrong member

### DIFF
--- a/nasim/envs/environment.py
+++ b/nasim/envs/environment.py
@@ -424,7 +424,7 @@ class NASimEnv(gym.Env):
         mask = np.zeros(self.action_space.n, dtype=np.int64)
         for a_idx in range(self.action_space.n):
             action = self.action_space.get_action(a_idx)
-            if self.network.host_discovered(action.target):
+            if self.current_state.host_discovered(action.target):
                 mask[a_idx] = 1
         return mask
 

--- a/nasim/scenarios/loader.py
+++ b/nasim/scenarios/loader.py
@@ -310,7 +310,7 @@ class ScenarioLoader:
             (f"{e_name}. Exploit target OS is invalid. '{e[u.EXPLOIT_OS]}'."
              " Should be None or one of the OS in the os list.")
 
-        assert 0 <= e[u.EXPLOIT_PROB] < 1, \
+        assert 0 <= e[u.EXPLOIT_PROB] <= 1.0, \
             (f"{e_name}. Exploit probability, '{e[u.EXPLOIT_PROB]}' not "
              "a valid probability")
 


### PR DESCRIPTION
I noticed that calling the 'get_action_mask' function on any environment fails with the error

```
>>> env.get_action_mask()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/conda/lib/python3.11/site-packages/nasim/envs/environment.py", line 427, in get_action_mask
    if self.network.host_discovered(action.target):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Network' object has no attribute 'host_discovered'
```

host_discovered is a method of the state class instead of the network class. It is a one-word fix.